### PR TITLE
Fixed incomplete cv2.imwrite monkey patch

### DIFF
--- a/utils/general.py
+++ b/utils/general.py
@@ -1118,9 +1118,9 @@ def imread(path, flags=cv2.IMREAD_COLOR):
     return cv2.imdecode(np.fromfile(path, np.uint8), flags)
 
 
-def imwrite(path, im):
+def imwrite(path, im, params=None):
     try:
-        cv2.imencode(Path(path).suffix, im)[1].tofile(path)
+        cv2.imencode(Path(path).suffix, im, params)[1].tofile(path)
         return True
     except Exception:
         return False


### PR DESCRIPTION
Monkey-patching of external libraries should be avoided at any cost.

