### PR TITLE
Fixed REB3-12048: RuntimeError incompatible numpy version

### DIFF
--- a/utils/general.py
+++ b/utils/general.py
@@ -413,6 +413,10 @@ def check_requirements(requirements=ROOT / 'requirements.txt', exclude=(), insta
             LOGGER.warning(f'{prefix} ❌ {e}')
 
 
+class MissingRequirement(Exception):
+    pass
+
+
 def check_img_size(imgsz, s=32, floor=0):
     # Verify image size is a multiple of stride s in each dimension
     if isinstance(imgsz, int):  # integer i.e. img_size=640


### PR DESCRIPTION
DetectMultiBackend runs `pip install onnxruntime` in case when `onnxruntime-gpu` is present in the system and CUDA is not available. This actually is not required as `onnxruntime-gpu` already contains all the needed providers.

It's a bad practice to install packages dynamically during runtime ignoring the requirements that developers are tailored for the execution environment. This leads to a binary incompatibility of the packages and other issues. And also in some cases it could just slow down system cold starts. It's better to check whether system initialization is possible in the current environment and fallback to package installation if there's no other way to continue.